### PR TITLE
PR/Branches badges side menu: Re-insert if any side menu mount/re-mount

### DIFF
--- a/src/background-for-requests.js
+++ b/src/background-for-requests.js
@@ -80,8 +80,13 @@ async function get<T: Object>(
             Authorization: `Bearer ${token}`,
         }),
     })
-    const result: BitbucketAPIErrorResponse | T = await response.json()
-    return result
+    try {
+        const result: BitbucketAPIErrorResponse | T = await response.json()
+        return result
+    } catch (ex) {
+        console.error(ex)
+        return ex
+    }
 }
 
 function exhaustiveCheck(value: empty) {

--- a/src/sidebar-counters/sidebar-counters.css
+++ b/src/sidebar-counters/sidebar-counters.css
@@ -1,17 +1,26 @@
 .__rbb-badge {
     position: absolute;
-    right: 4px;
-    bottom: -1px;
+    right: 5px;
+    width: 1.6em;
+    height: 1.6em;
+}
+
+.__rbb-badge::before {
+    content: '';
+    background: #a00;
+    border-radius: 1em;
+    position: absolute;
+    width: 100%;
+    height: 100%;
 }
 
 .__rbb-badge-counter {
-    font-weight: 650;
-    font-size: 10px;
-    border-radius: 50%;
-    height: 100%;
-    width: 100%;
-    box-sizing: border-box;
-    align-content: center;
-    align-items: center;
-    padding: 2px;
+    color: #fff;
+    font-weight: 800;
+    font-size: 0.8em;
+    position: absolute;
+    text-align: center;
+    line-height: 1.9em;
+    right: 0;
+    left: 0;
 }

--- a/src/sidebar-counters/sidebar-counters.css
+++ b/src/sidebar-counters/sidebar-counters.css
@@ -1,8 +1,8 @@
 .__rbb-badge {
     position: absolute;
     right: 5px;
-    width: 1.6em;
-    height: 1.6em;
+    width: 1.5em;
+    height: 1.5em;
 }
 
 .__rbb-badge::before {
@@ -16,7 +16,7 @@
 
 .__rbb-badge-counter {
     color: #fff;
-    font-weight: 800;
+    font-weight: 600;
     font-size: 0.8em;
     position: absolute;
     text-align: center;
@@ -27,5 +27,5 @@
 
 .__rbb-badge-counter.-max::before {
     content: '+';
-    margin: -0.2em;
+    font-weight: 200;
 }

--- a/src/sidebar-counters/sidebar-counters.css
+++ b/src/sidebar-counters/sidebar-counters.css
@@ -24,3 +24,8 @@
     right: 0;
     left: 0;
 }
+
+.__rbb-badge-counter.-max::before {
+    content: '+';
+    margin: -0.2em;
+}

--- a/src/sidebar-counters/sidebar-counters.js
+++ b/src/sidebar-counters/sidebar-counters.js
@@ -10,11 +10,14 @@ import './sidebar-counters.css'
 
 const HREF_BRANCHES = 'branches'
 const HREF_PULL_REQUESTS = 'pull-requests'
-const menus = [HREF_BRANCHES, HREF_PULL_REQUESTS]
+export const menus = [HREF_BRANCHES, HREF_PULL_REQUESTS]
 
 const MAX_COUNTER = 99
 
-let menusCounters = {}
+export let menusCounters = {
+    HREF_BRANCHES: null,
+    HREF_PULL_REQUESTS: null,
+}
 
 type ResultSize = $Exact<{ size: number }>
 
@@ -52,17 +55,7 @@ export async function addCounterToMenuItem(menu: HTMLElement) {
     // that we are going to augment with badge counters
     if (!wantedMenuFromHref) return
 
-    const resources: ResultSize | void = await getCounterInfo(
-        wantedMenuFromHref
-    )
-    const { size: currentSize } = resources || {}
-
-    // Fallback to old count if it fails to retrieve the new count
-    const size =
-        typeof currentSize === 'number'
-            ? currentSize
-            : menusCounters[wantedMenuFromHref]
-
+    const size = menusCounters[wantedMenuFromHref]
     const badge = getBadge(size)
 
     menu.style.overflow = 'hidden'
@@ -71,10 +64,11 @@ export async function addCounterToMenuItem(menu: HTMLElement) {
 }
 
 export default async function addSideBarCounters() {
-    menusCounters = menus.reduce(
-        async (acc, menu) => ({ [menu]: await getCounterInfo(menu) }),
-        {}
-    )
+    menus.forEach(async menu => {
+        const resources = await getCounterInfo(menu)
+        const { size: currentSize } = resources || {}
+        menusCounters[menu] = currentSize
+    })
     const contentNavigationSelector =
         'div[data-testid="Content"] div[role="presentation"]'
     const contextualNavigationSelector =

--- a/src/sidebar-counters/sidebar-counters.js
+++ b/src/sidebar-counters/sidebar-counters.js
@@ -13,7 +13,8 @@ const HREF_PULL_REQUESTS = 'pull-requests'
 
 type ResultSize = $Exact<{ size: number }>
 
-export function getBadge(size?: number): HTMLElement {
+export function getBadge(resources: ResultSize | void): HTMLElement {
+    const size = resources ? resources.size : undefined
     return (
         <span class="__rbb-badge">
             <span class="__rbb-badge-counter">
@@ -34,7 +35,7 @@ async function getCounterInfo(wantedMenuFromHref: string): Promise {
     }
 }
 
-async function addBadgesToMenu(menu: HTMLElement) {
+export async function addCounterToMenuItem(menu: HTMLElement) {
     const link: HTMLAnchorElement = menu.querySelector('a')
 
     if (!link) return
@@ -52,8 +53,7 @@ async function addBadgesToMenu(menu: HTMLElement) {
         wantedMenuFromHref
     )
 
-    const size = resources ? resources.size : undefined
-    const badge = getBadge(size)
+    const badge = getBadge(resources)
 
     menu.style.overflow = 'hidden'
     link.style.position = 'relative'
@@ -69,7 +69,7 @@ export default async function addSideBarCounters() {
         document.body,
         [contentNavigationSelector, contextualNavigationSelector].join(', '),
         function() {
-            addBadgesToMenu(this)
+            addCounterToMenuItem(this)
         }
     )
 }

--- a/src/sidebar-counters/sidebar-counters.spec.js
+++ b/src/sidebar-counters/sidebar-counters.spec.js
@@ -8,18 +8,15 @@ import 'selector-observer'
 import {
     getBadge,
     addCounterToMenuItem,
-    menusCounters,
     menus,
+    HREF_PULL_REQUESTS,
+    HREF_BRANCHES,
 } from './sidebar-counters'
 import addSidebarCounters from '.'
 
 global.fetch = {}
 
 const size = 10
-
-menus.forEach(m => {
-    menusCounters[m] = size
-})
 
 test.afterEach(() => {
     cleanDocumentBody()
@@ -54,9 +51,14 @@ test('getBadge should add up to 99 using response size number', t => {
 })
 
 test.serial(
-    'addCounterToMenuItem should add properly branches counter to branches menu link',
+    'addCounterToMenuItem should fail if no menu link found',
     async t => {
         // Arrange
+        const menusCounters: MenuCounter = {
+            [HREF_BRANCHES]: null,
+            [HREF_PULL_REQUESTS]: 0,
+        }
+
         const menu = (
             <div role="presentation">
                 <a href="/user/repo/branches/" />
@@ -66,7 +68,41 @@ test.serial(
         const expected = (
             <div role="presentation" style={{ overflow: 'hidden' }}>
                 <a href="/user/repo/branches/" style={{ position: 'relative' }}>
-                    <span class="__rbb-badge">
+                    <span class="__rbb-badge" title="">
+                        <span class="__rbb-badge-counter">!</span>
+                    </span>
+                </a>
+            </div>
+        )
+
+        // Act
+        await addCounterToMenuItem(menu, menusCounters)
+
+        // Assert
+        t.is(menu.outerHTML, expected.outerHTML)
+        t.pass()
+    }
+)
+
+test.serial(
+    'addCounterToMenuItem should add properly branches counter to branches menu link',
+    async t => {
+        // Arrange
+        const menusCounters: MenuCounter = {
+            [HREF_BRANCHES]: size,
+            [HREF_PULL_REQUESTS]: 0,
+        }
+
+        const menu = (
+            <div role="presentation">
+                <a href="/user/repo/branches/" />
+            </div>
+        )
+
+        const expected = (
+            <div role="presentation" style={{ overflow: 'hidden' }}>
+                <a href="/user/repo/branches/" style={{ position: 'relative' }}>
+                    <span class="__rbb-badge" title={size}>
                         <span class="__rbb-badge-counter">{size}</span>
                     </span>
                 </a>
@@ -74,7 +110,7 @@ test.serial(
         )
 
         // Act
-        await addCounterToMenuItem(menu)
+        await addCounterToMenuItem(menu, menusCounters)
 
         // Assert
         t.is(menu.outerHTML, expected.outerHTML)
@@ -86,6 +122,11 @@ test.serial(
     'addCounterToMenuItem should add properly pull-requests counter to pull-requests menu link',
     async t => {
         // Arrange
+        const menusCounters: MenuCounter = {
+            [HREF_BRANCHES]: 0,
+            [HREF_PULL_REQUESTS]: size,
+        }
+
         const menu = (
             <div role="presentation">
                 <a href="/user/repo/pull-requests/" />
@@ -98,7 +139,7 @@ test.serial(
                     href="/user/repo/pull-requests/"
                     style={{ position: 'relative' }}
                 >
-                    <span class="__rbb-badge">
+                    <span class="__rbb-badge" title={size}>
                         <span class="__rbb-badge-counter">{size}</span>
                     </span>
                 </a>
@@ -106,7 +147,7 @@ test.serial(
         )
 
         // Act
-        await addCounterToMenuItem(menu)
+        await addCounterToMenuItem(menu, menusCounters)
 
         // Assert
         t.is(menu.outerHTML, expected.outerHTML)
@@ -118,6 +159,10 @@ test.serial(
     'addCounterToMenuItem should not add counter to unknown menu link',
     async t => {
         // Arrange
+        const menusCounters: MenuCounter = {
+            [HREF_BRANCHES]: size,
+            [HREF_PULL_REQUESTS]: size,
+        }
         const menu = (
             <div role="presentation">
                 <a href="/user/repo/commits/" />
@@ -125,7 +170,7 @@ test.serial(
         )
 
         // Act
-        await addCounterToMenuItem(menu)
+        await addCounterToMenuItem(menu, menusCounters)
 
         // Assert
         t.is(menu.outerHTML, menu.outerHTML)

--- a/src/sidebar-counters/sidebar-counters.spec.js
+++ b/src/sidebar-counters/sidebar-counters.spec.js
@@ -5,116 +5,100 @@ import '../../test/setup-jsdom'
 
 import 'selector-observer'
 
-import { addBadge } from './sidebar-counters'
+import { getBadge, addCounterToMenuItem } from './sidebar-counters'
 import addSidebarCounters from '.'
 
 global.fetch = {}
+
+const size = 10
+
+test.beforeEach(() => {
+    global.chrome = {
+        runtime: {
+            sendMessage: (data, cb) => {
+                cb({ size })
+            },
+        },
+    }
+})
 
 test.afterEach(() => {
     cleanDocumentBody()
 })
 
-test('addBadge should work properly', t => {
-    // Arrange
-    const actual = (
-        <div>
-            <a aria-disabled="false" href="/user/repo/branches/" class="jRoiuT">
-                <span class="bGyZgY" />
-            </a>
-        </div>
-    )
-
-    const size = 5
-    const expected = (
-        <div style={{ overflow: 'hidden' }}>
-            <a
-                aria-disabled="false"
-                href="/user/repo/branches/"
-                class="jRoiuT"
-                style={{ position: 'relative' }}
-            >
-                <span class="__rbb-badge">
-                    <span class="__rbb-badge-counter">{size}</span>
-                </span>
-                <span class="bGyZgY" />
-            </a>
-        </div>
-    )
-
-    // Act
-    const a = actual.firstChild
-    const badge = addBadge(a, { size })
-
-    // Assert
-    t.is(actual.outerHTML, expected.outerHTML)
-    t.true(badge instanceof HTMLSpanElement)
-})
-
-test('addBadge should add ? character if response fails or has unexpected shape', t => {
-    // Arrange
-    const template = (
-        <div>
-            <a aria-disabled="false" href="/user/repo/branches/" class="jRoiuT">
-                <span class="bGyZgY" />
-            </a>
-        </div>
-    )
-
+test('getBadge should add ! character if response fails or has unexpected shape', t => {
     // Act & Assert 1
-    const actual1 = template.cloneNode(true)
-    addBadge(actual1.firstChild, undefined)
-    t.is(actual1.querySelector('.__rbb-badge-counter').textContent, '?')
+    const actual1 = getBadge(undefined)
+    t.is(actual1.querySelector('.__rbb-badge-counter').textContent, '!')
 
     // Act  & Assert 2
-    const actual2 = template.cloneNode(true)
-    addBadge(actual2.firstChild, null)
-    t.is(actual2.querySelector('.__rbb-badge-counter').textContent, '?')
+    const actual2 = getBadge(null)
+    t.is(actual2.querySelector('.__rbb-badge-counter').textContent, '!')
 
     // Act  & Assert 3
-    const actual3 = template.cloneNode(true)
-    addBadge(actual3.firstChild, {})
-    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '?')
+    const actual3 = getBadge({})
+    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '!')
 
     // Act  & Assert 4
-    const actual4 = template.cloneNode(true)
-    addBadge(actual4.firstChild, { size: null })
-    t.is(actual4.querySelector('.__rbb-badge-counter').textContent, '?')
-
-    // Act  & Assert 5
-    const actual5 = template.cloneNode(true)
-    addBadge(actual5.firstChild, { size: 0 })
-    t.is(actual5.querySelector('.__rbb-badge-counter').textContent, '0')
+    const actual4 = getBadge({ size: null })
+    t.is(actual4.querySelector('.__rbb-badge-counter').textContent, '!')
 })
 
-test.serial('addSidebarCounters should work properly', async t => {
-    // Arrange
-    const nav = (
-        <div>
-            <div>
+test('getBadge should add up to 99 using response size number', t => {
+    // Act  & Assert 1
+    const actual1 = getBadge({ size: 0 })
+    t.is(actual1.querySelector('.__rbb-badge-counter').textContent, '0')
+
+    // Act  & Assert 2
+    const actual2 = getBadge({ size: 99 })
+    t.is(actual2.querySelector('.__rbb-badge-counter').textContent, '99')
+
+    // Act  & Assert 3
+    const actual3 = getBadge({ size: 100 })
+    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '+99')
+})
+
+test.serial(
+    'addCounterToMenuItem should add properly branches counter to branches menu link',
+    async t => {
+        // Arrange
+        const menu = (
+            <div role="presentation">
                 <a href="/user/repo/branches/" />
             </div>
-            <div>
-                <a href="/user/repo/pull-requests/" />
-            </div>
+        )
 
-            <button class="ak-navigation-resize-button" aria-expanded="false">
-                Resize
-            </button>
-        </div>
-    )
-    document.body.appendChild(nav)
-
-    const size = 10
-    const expected = (
-        <div>
-            <div style={{ overflow: 'hidden' }}>
+        const expected = (
+            <div role="presentation" style={{ overflow: 'hidden' }}>
                 <a href="/user/repo/branches/" style={{ position: 'relative' }}>
                     <span class="__rbb-badge">
                         <span class="__rbb-badge-counter">{size}</span>
                     </span>
                 </a>
             </div>
-            <div style={{ overflow: 'hidden' }}>
+        )
+
+        // Act
+        await addCounterToMenuItem(menu)
+
+        // Assert
+        t.is(menu.outerHTML, expected.outerHTML)
+        t.pass()
+    }
+)
+
+test.serial(
+    'addCounterToMenuItem should add properly pull-requests counter to pull-requests menu link',
+    async t => {
+        // Arrange
+        const menu = (
+            <div role="presentation">
+                <a href="/user/repo/pull-requests/" />
+            </div>
+        )
+
+        const expected = (
+            <div role="presentation" style={{ overflow: 'hidden' }}>
                 <a
                     href="/user/repo/pull-requests/"
                     style={{ position: 'relative' }}
@@ -124,25 +108,32 @@ test.serial('addSidebarCounters should work properly', async t => {
                     </span>
                 </a>
             </div>
+        )
 
-            <button class="ak-navigation-resize-button" aria-expanded="false">
-                Resize
-            </button>
-        </div>
-    )
+        // Act
+        await addCounterToMenuItem(menu)
 
-    global.chrome = {
-        runtime: {
-            sendMessage: (data, cb) => {
-                cb({ size })
-            },
-        },
+        // Assert
+        t.is(menu.outerHTML, expected.outerHTML)
+        t.pass()
     }
+)
 
-    // Act
-    await addSidebarCounters()
+test.serial(
+    'addCounterToMenuItem should not add counter to unknown menu link',
+    async t => {
+        // Arrange
+        const menu = (
+            <div role="presentation">
+                <a href="/user/repo/commits/" />
+            </div>
+        )
 
-    // Assert
-    t.is(nav.outerHTML, expected.outerHTML)
-    t.pass()
-})
+        // Act
+        await addCounterToMenuItem(menu)
+
+        // Assert
+        t.is(menu.outerHTML, menu.outerHTML)
+        t.pass()
+    }
+)

--- a/src/sidebar-counters/sidebar-counters.spec.js
+++ b/src/sidebar-counters/sidebar-counters.spec.js
@@ -5,21 +5,20 @@ import '../../test/setup-jsdom'
 
 import 'selector-observer'
 
-import { getBadge, addCounterToMenuItem } from './sidebar-counters'
+import {
+    getBadge,
+    addCounterToMenuItem,
+    menusCounters,
+    menus,
+} from './sidebar-counters'
 import addSidebarCounters from '.'
 
 global.fetch = {}
 
 const size = 10
 
-test.beforeEach(() => {
-    global.chrome = {
-        runtime: {
-            sendMessage: (data, cb) => {
-                cb({ size })
-            },
-        },
-    }
+menus.forEach(m => {
+    menusCounters[m] = size
 })
 
 test.afterEach(() => {

--- a/src/sidebar-counters/sidebar-counters.spec.js
+++ b/src/sidebar-counters/sidebar-counters.spec.js
@@ -27,35 +27,31 @@ test.afterEach(() => {
 })
 
 test('getBadge should add ! character if response fails or has unexpected shape', t => {
-    // Act & Assert 1
+    // Act  & Assert 1
     const actual1 = getBadge(undefined)
     t.is(actual1.querySelector('.__rbb-badge-counter').textContent, '!')
 
     // Act  & Assert 2
     const actual2 = getBadge(null)
     t.is(actual2.querySelector('.__rbb-badge-counter').textContent, '!')
-
-    // Act  & Assert 3
-    const actual3 = getBadge({})
-    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '!')
-
-    // Act  & Assert 4
-    const actual4 = getBadge({ size: null })
-    t.is(actual4.querySelector('.__rbb-badge-counter').textContent, '!')
 })
 
 test('getBadge should add up to 99 using response size number', t => {
     // Act  & Assert 1
-    const actual1 = getBadge({ size: 0 })
+    const actual1 = getBadge(0)
     t.is(actual1.querySelector('.__rbb-badge-counter').textContent, '0')
 
     // Act  & Assert 2
-    const actual2 = getBadge({ size: 99 })
+    const actual2 = getBadge(99)
     t.is(actual2.querySelector('.__rbb-badge-counter').textContent, '99')
 
     // Act  & Assert 3
-    const actual3 = getBadge({ size: 100 })
-    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '+99')
+    const actual3 = getBadge(100)
+
+    t.is(actual3.querySelector('.__rbb-badge-counter').textContent, '99')
+    t.true(
+        actual3.querySelector('.__rbb-badge-counter').classList.contains('-max')
+    )
 })
 
 test.serial(


### PR DESCRIPTION
Once again I updated a feature on my fork, so here, I share it.
- I noticed the counters were not accurate, now it fetches on mount, so we will see more often a valid badge counter when using the floating-contextual-collapsed-menu
- If the menu was unmounted the badge never came back, now it uses `SelectorObserver`
- I handled the other menu, contextual floating menu, the one that appears when the other menu is collapsed and you just hover the side menu line.
- I noticed bitbucket does not have menu link icons when the menu is collapsed, so I added badges
- I reduced the max number from `99999+` to `+99` since in my opinion having more than 99 it's a sign that you lost track of it, you must do some clean up to reduce the counter. Just like messaging app can easily go over 99 but they also show `+99` when you don't care enough to clean your messages. So normally users, should care about having branches over 50, and PR over 10/20. Here at work on the biggest project we never went over 20 branches and 20 PRs, normally they close in 2hrs to 6hrs.
- I changed `?` to `!` for the only matter that `?` can't be centred in the badge, and i chose `!` cause it's quite common to see it when an error occurred, here the api did not responded, bad token
- I made sure it works with the new pull request experience, UI V2

![image](https://user-images.githubusercontent.com/23088305/80050885-d3db5c80-84e4-11ea-831a-998958cda9b5.png)

![g](https://user-images.githubusercontent.com/23088305/80053404-d771e200-84ea-11ea-8089-cde16b9dce00.gif)

![image](https://user-images.githubusercontent.com/23088305/80054389-17d25f80-84ed-11ea-98ba-37bc9d1eb54d.png)

<!--
    Check those that apply, and delete the ones that don't
-->

-   [ ] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [x] I added Automated Tests
-   [ ] I added an Option to enable / disable this feature
-   [ ] I updated the README.md, with pictures if necessary

---

close #185 
