### PR TITLE
Collapse diff scrolling effect only on bottom toggle

### DIFF
--- a/src/collapse-diff/collapse-diff.js
+++ b/src/collapse-diff/collapse-diff.js
@@ -188,16 +188,18 @@ export function insertCollapseDiffButton(section: HTMLElement) {
         return
     }
 
-    const onClick = () => {
+    const onClick = ({ scrollingEffect }) => () => {
         toggleDiff(section)
 
         // Scrolling to diff
-        section.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        if (scrollingEffect) {
+            section.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }
     }
 
     const topButton = insertTopButton(section)
     const bottomButton = insertBottomButton(section)
 
-    topButton.addEventListener('click', onClick)
-    bottomButton.addEventListener('click', onClick)
+    topButton.addEventListener('click', onClick({ scrollingEffect: false }))
+    bottomButton.addEventListener('click', onClick({ scrollingEffect: true }))
 }


### PR DESCRIPTION
if the header never reached the top of the screen we should normally don't add the scrolling effect when collapsing.

![gh](https://user-images.githubusercontent.com/23088305/82134833-103f6700-97ca-11ea-9f1a-83fc90646781.gif)

close #356 