### PR TITLE
Collapse pull request side menus on load

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,6 +21,8 @@ new OptionsSync().define({
         copyFilename: true,
         keymap: true,
         collapsePullRequestDescription: true,
+        collapsePullRequestSideMenus: true,
+        collapsePrSideMenusResolutionSize: 1360,
         collapseDiff: true,
         loadAllDiffs: true,
         closeAnchorBranch: true,

--- a/src/collapse-pull-request-side-menus/collapse-pull-request-side-menus.js
+++ b/src/collapse-pull-request-side-menus/collapse-pull-request-side-menus.js
@@ -1,0 +1,13 @@
+export default function collapsePullRequestSideMenus(windowWidth) {
+    if (windowWidth > 0 && windowWidth < window.innerWidth) return
+
+    const left = document.querySelector(
+        'button[data-qa-id="expand-collapse-button"][aria-expanded="true"]'
+    )
+    if (left) left.click()
+
+    const right = document.querySelector(
+        '#PullRequestWelcomeTourTarget-Sidebar button[data-testid="collapse-sidebar-button"][aria-expanded="true"]'
+    )
+    if (right) right.click()
+}

--- a/src/collapse-pull-request-side-menus/index.js
+++ b/src/collapse-pull-request-side-menus/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './collapse-pull-request-side-menus'

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ import mergeCommitMessageNew from './merge-commit-message-new'
 import collapsePullRequestDescription from './collapse-pull-request-description'
 import setStickyHeader from './sticky-header'
 import setLineLengthLimit from './limit-line-length'
+import collapsePullRequestSideMenus from './collapse-pull-request-side-menus'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -225,6 +226,10 @@ function pullrequestRelatedFeaturesNew(config) {
         mergeCommitMessageNew(config.mergeCommitMessageUrl)
     }
 
+    if (config.collapsePullRequestSideMenus) {
+        collapsePullRequestSideMenus(config.collapsePrSideMenusResolutionSize)
+    }
+
     if (config.copyFilename) {
         // eslint-disable-next-line no-new
         new SelectorObserver(
@@ -258,5 +263,9 @@ function pullrequestRelatedFeaturesOld(config) {
 
     if (config.collapsePullRequestDescription) {
         collapsePullRequestDescription()
+    }
+
+    if (config.collapsePullRequestSideMenus) {
+        collapsePullRequestSideMenus(config.collapsePrSideMenusResolutionSize)
     }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -30,7 +30,7 @@
         <br />
 
         <label>
-            <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore
+            <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore 
             whitespace" ON by default in the Old PR Experience 
             (already natively supported in the New PR experience)
         </label>

--- a/src/options.html
+++ b/src/options.html
@@ -1,325 +1,276 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <title>Refined Bitbucket Options</title>
-    </head>
 
-    <body>
-        <form id="options-form" style="width: 600px">
-            <label>
-                <input type="checkbox" name="syntaxHighlight" /> Syntax
-                highlighting
-            </label>
-            <br />
-            <br />
+<head>
+    <meta charset="UTF-8" />
+    <title>Refined Bitbucket Options</title>
+</head>
 
-            <label>
-                <input type="checkbox" name="autolinker" /> Autolinker: Linkify
-                links in diffs
-            </label>
-            <br />
-            <br />
+<body>
+    <form id="options-form" style="width: 600px">
+        <label>
+            <input type="checkbox" name="syntaxHighlight" /> Syntax
+            highlighting
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="highlightOcurrences" /> Highlight
-                occurrences of selected words
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="autolinker" /> Autolinker: Linkify
+            links in diffs
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore
-                whitespace" ON by default when entering a Pull request from the
-                Pull requests list page
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="highlightOcurrences" /> Highlight
+            occurrences of selected words
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="keymap" /> Enable keyboard mappings
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore
+            whitespace" ON by default when entering a Pull request from the
+            Pull requests list page
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="collapsePullRequestDescription" />
-                Add button to collapse pull request descriptions
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="keymap" /> Enable keyboard mappings
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="collapseDiff" /> Add "Toggle diff
-                text" button to collapse diff sections
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="collapsePullRequestDescription" />
+            Add button to collapse pull request descriptions
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="loadAllDiffs" /> Add "Load all
-                diffs" button that automatically loads every failed diff of the
-                pull request simultaneously
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="collapsePullRequestSideMenus" />
+            By default on a pull request, collapse side menus when screen width is under
+            <input type="number" name="collapsePrSideMenusResolutionSize" min="0" style="width: 60px;" />
+            <span>px. (0 = unlimited)</span>
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="closeAnchorBranch" /> Check the
-                "Close anchor branch" checkbox by default when creating a new
-                pull request
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="collapseDiff" /> Add "Toggle diff
+            text" button to collapse diff sections
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="addSidebarCounters" /> Add counters
-                to the "Branches" and "Pull requests" links in the navigation
-                sidebar menu.
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="loadAllDiffs" /> Add "Load all
+            diffs" button that automatically loads every failed diff of the
+            pull request simultaneously
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="augmentPrEntry" /> Add source
-                branch, linkify branch names, and add creation date to each pull
-                request row in pull request list view.
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="closeAnchorBranch" /> Check the
+            "Close anchor branch" checkbox by default when creating a new
+            pull request
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="comparePagePullRequest" /> Add the
-                'Create a Pull Request' button to the 'Compare branches and
-                tags' page view.
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="addSidebarCounters" /> Add counters
+            to the "Branches" and "Pull requests" links in the navigation
+            sidebar menu.
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="diffPlusesAndMinuses" /> Don't
-                carry pluses and minuses to clipboard when copying diff's
-                contents
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="augmentPrEntry" /> Add source
+            branch, linkify branch names, and add creation date to each pull
+            request row in pull request list view.
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="pullrequestCommitAmount" /> Include
-                number of commits next to the Commits tab in the pull request
-                view
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="comparePagePullRequest" /> Add the
+            'Create a Pull Request' button to the 'Compare branches and
+            tags' page view.
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="copyFilename" /> Insert "Copy
-                filename to clipboard" button in diff header
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="diffPlusesAndMinuses" /> Don't
+            carry pluses and minuses to clipboard when copying diff's
+            contents
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="customTabSizeEnabled" /> Tab
-                indentation size:
-                <input
-                    type="number"
-                    name="customTabSize"
-                    min="0"
-                    max="16"
-                    style="width: 40px;"
-                />
-                <span>spaces.</span>
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="pullrequestCommitAmount" /> Include
+            number of commits next to the Commits tab in the pull request
+            view
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="lineLengthLimitEnabled" />
-                Set a line limit of
-                <input
-                    type="number"
-                    name="lineLengthLimit"
-                    min="0"
-                    max="200"
-                    style="width: 40px;"
-                />
-                columns.
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="copyFilename" /> Insert "Copy
+            filename to clipboard" button in diff header
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="showCommentsCheckbox" /> Insert
-                "Comments" checkbox in diff header to toggle comments.
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="customTabSizeEnabled" /> Tab
+            indentation size:
+            <input type="number" name="customTabSize" min="0" max="16" style="width: 40px;" />
+            <span>spaces.</span>
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="stickyHeader" /> Sticky Header -
-                Ensure filename and actions toolbar is always visible even for
-                long diffs
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="lineLengthLimitEnabled" />
+            Set a line limit of
+            <input type="number" name="lineLengthLimit" min="0" max="200" style="width: 40px;" />
+            columns.
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="prTemplateEnabled" /> Use a
-                <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when
-                creating new pull requests or specify a URL with your own raw
-                template (must be hosted publicly in
-                <a href="http://gist.github.com/">http://gist.github.com/</a>).
-                See the
-                <a href="http://github.com/refined-bitbucket/refined-bitbucket"
-                    >README</a
-                >
-                of the extension for more details on how this works.
-                <i
-                    >Note: Currently, externally hosted pull request templates
-                    outside of Bitbucket's domain is not supported with the
-                    Firefox addon.</i
-                >
-                <input type="text" name="prTemplateUrl" style="width: 100%;" />
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="showCommentsCheckbox" /> Insert
+            "Comments" checkbox in diff header to toggle comments.
+        </label>
+        <br />
+        <br />
 
-            <label>
-                <input type="checkbox" name="mergeCommitMessageEnabled" /> Use a
-                <em>MERGE_COMMIT_TEMPLATE</em> from the repository or specify a
-                URL with your own raw template where you can use variables like
-                `id`, `title`, `description` and more. See the
-                <a href="http://github.com/refined-bitbucket/refined-bitbucket"
-                    >README</a
-                >
-                of the extension for more details on how this works.
-                <i>
-                    Note: Currently, externally hosted templates (outside from
-                    Bitbucket's domain) are only tested with
-                    <a href="http://gist.github.com/">http://gist.github.com/</a
-                    >, and are not supported with the Firefox addon.
-                </i>
-                <input
-                    type="text"
-                    name="mergeCommitMessageUrl"
-                    style="width: 100%;"
-                />
-            </label>
-            <br />
-            <br />
+        <label>
+            <input type="checkbox" name="stickyHeader" /> Sticky Header -
+            Ensure filename and actions toolbar is always visible even for
+            long diffs
+        </label>
+        <br />
+        <br />
 
-            <label> Default Merge Strategy </label>
-            <div
-                name="default-merge-strategy-form"
-                style="margin: 0.5em 0 0 1em;"
-            >
-                <input type="radio" name="defaultMergeStrategy" value="none" />
-                None
-                <input
-                    type="radio"
-                    name="defaultMergeStrategy"
-                    value="merge_commit"
-                    checked
-                />
-                Merge commit
-                <input
-                    type="radio"
-                    name="defaultMergeStrategy"
-                    value="squash"
-                />
-                Squash
-                <input
-                    type="radio"
-                    name="defaultMergeStrategy"
-                    value="fast_forward"
-                />
-                Fast forward
-            </div>
-            <br />
+        <label>
+            <input type="checkbox" name="prTemplateEnabled" /> Use a
+            <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when
+            creating new pull requests or specify a URL with your own raw
+            template (must be hosted publicly in
+            <a href="http://gist.github.com/">http://gist.github.com/</a>).
+            See the
+            <a href="http://github.com/refined-bitbucket/refined-bitbucket">README</a>
+            of the extension for more details on how this works.
+            <i>Note: Currently, externally hosted pull request templates
+                outside of Bitbucket's domain is not supported with the
+                Firefox addon.</i>
+            <input type="text" name="prTemplateUrl" style="width: 100%;" />
+        </label>
+        <br />
+        <br />
 
+        <label>
+            <input type="checkbox" name="mergeCommitMessageEnabled" /> Use a
+            <em>MERGE_COMMIT_TEMPLATE</em> from the repository or specify a
+            URL with your own raw template where you can use variables like
+            `id`, `title`, `description` and more. See the
+            <a href="http://github.com/refined-bitbucket/refined-bitbucket">README</a>
+            of the extension for more details on how this works.
+            <i>
+                Note: Currently, externally hosted templates (outside from
+                Bitbucket's domain) are only tested with
+                <a href="http://gist.github.com/">http://gist.github.com/</a>, and are not supported with the Firefox
+                addon.
+            </i>
+            <input type="text" name="mergeCommitMessageUrl" style="width: 100%;" />
+        </label>
+        <br />
+        <br />
+
+        <label> Default Merge Strategy </label>
+        <div name="default-merge-strategy-form" style="margin: 0.5em 0 0 1em;">
+            <input type="radio" name="defaultMergeStrategy" value="none" />
+            None
+            <input type="radio" name="defaultMergeStrategy" value="merge_commit" checked />
+            Merge commit
+            <input type="radio" name="defaultMergeStrategy" value="squash" />
+            Squash
+            <input type="radio" name="defaultMergeStrategy" value="fast_forward" />
+            Fast forward
+        </div>
+        <br />
+
+        <div>
             <div>
-                <div>
-                    <label>
-                        <strong
-                            >Files to autocollapse. Use the same patterns as
-                            with .gitignore.</strong
-                        >
-                        <br />
-                        The files that match the given patterns will be
-                        automatically collapsed when the Pull Request loads.
-                    </label>
-                </div>
-                <textarea
-                    name="autocollapsePaths"
-                    rows="7"
-                    style="width: 100%"
-                ></textarea>
-                <br />
                 <label>
-                    <input type="checkbox" name="autocollapseDeletedFiles" />
-                    Autocollapse deleted files
+                    <strong>Files to autocollapse. Use the same patterns as
+                        with .gitignore.</strong>
+                    <br />
+                    The files that match the given patterns will be
+                    automatically collapsed when the Pull Request loads.
                 </label>
             </div>
+            <textarea name="autocollapsePaths" rows="7" style="width: 100%"></textarea>
             <br />
-
-            <div>
-                <div>
-                    <label>
-                        <strong
-                            >Diff ignore. Use the same patterns as with
-                            .gitignore.</strong
-                        >
-                        <div>
-                            The files that match the given patterns will be
-                            completely removed and inaccessible in the Pull
-                            Request / Commit view.
-                        </div>
-                    </label>
-                </div>
-                <textarea
-                    name="ignorePaths"
-                    rows="7"
-                    style="width: 100%"
-                ></textarea>
-            </div>
-            <br />
-
-            <div>
-                <div>
-                    <label>
-                        <strong
-                            >Define your own CSS styles to be injected in every
-                            page</strong
-                        >
-                    </label>
-                </div>
-                <textarea
-                    name="customStyles"
-                    rows="7"
-                    style="width: 100%"
-                ></textarea>
-            </div>
-            <br />
-
-            <hr />
-            <label
-                style="display: flex; justify-content: space-between; align-items: center"
-            >
-                <span style="width: calc(100% - 30px)">
-                    Enable Update Notifications. Every time this extension is
-                    updated, the CHANGELOG for the current version will be
-                    opened in a new browser tab.
-                    <a
-                        href="https://github.com/refined-bitbucket/refined-bitbucket/issues/182"
-                        >Subscribe to this issue if you would like to get e-mail
-                        notifications on updates.</a
-                    >
-                </span>
-                <input type="checkbox" name="enableUpdateNotifications" />
+            <label>
+                <input type="checkbox" name="autocollapseDeletedFiles" />
+                Autocollapse deleted files
             </label>
-        </form>
+        </div>
+        <br />
 
-        <script src="options.js"></script>
-    </body>
+        <div>
+            <div>
+                <label>
+                    <strong>Diff ignore. Use the same patterns as with
+                        .gitignore.</strong>
+                    <div>
+                        The files that match the given patterns will be
+                        completely removed and inaccessible in the Pull
+                        Request / Commit view.
+                    </div>
+                </label>
+            </div>
+            <textarea name="ignorePaths" rows="7" style="width: 100%"></textarea>
+        </div>
+        <br />
+
+        <div>
+            <div>
+                <label>
+                    <strong>Define your own CSS styles to be injected in every
+                        page</strong>
+                </label>
+            </div>
+            <textarea name="customStyles" rows="7" style="width: 100%"></textarea>
+        </div>
+        <br />
+
+        <hr />
+        <label style="display: flex; justify-content: space-between; align-items: center">
+            <span style="width: calc(100% - 30px)">
+                Enable Update Notifications. Every time this extension is
+                updated, the CHANGELOG for the current version will be
+                opened in a new browser tab.
+                <a href="https://github.com/refined-bitbucket/refined-bitbucket/issues/182">Subscribe to this issue if
+                    you would like to get e-mail
+                    notifications on updates.</a>
+            </span>
+            <input type="checkbox" name="enableUpdateNotifications" />
+        </label>
+    </form>
+
+    <script src="options.js"></script>
+</body>
+
 </html>

--- a/src/sticky-header/sticky-header.js
+++ b/src/sticky-header/sticky-header.js
@@ -8,11 +8,12 @@ export default function setStickyHeader() {
 }
 
 function createCssRule() {
+    // z-index above 1 hide the dynamic side menu
     const cssRule = `
         .diff-container .heading {
             position: sticky;
             top: 0px;
-            z-index: 9;
+            z-index: 1;
             border: 1px solid #DFE1E6;
         }
 


### PR DESCRIPTION
- works for old and new pr experience
- no automated tests because the onClick event is handled by bitbucket
- added screen resolution support, default `1360`
- fixed sticky header that were above side menu zIndex > 1 . fixes #336 
<details><summary>[Click to view capture] The Sticky Header bug with z-index 9</summary>
<img src="https://user-images.githubusercontent.com/23088305/79061876-759bb780-7c62-11ea-9f25-60d2a975909a.gif" />
</details>

Since RB events don't trigger when navigating between PullRequest list and PR, which is a good thing, if the user expand the left side menu in or outside of a PR, it will stay like this when returning to a PR.

<!--
    Check those that apply, and delete the ones that don't
-->

-   [ ] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [ ] I added Automated Tests
-   [x] I added an Option to enable / disable this feature
-   [ ] I updated the README.md, with pictures if necessary

---

![collapse](https://user-images.githubusercontent.com/23088305/79062012-2060a580-7c64-11ea-81f4-df4ca24f6221.gif)

close #336